### PR TITLE
Fix bug with CreditNote replacements for Invoice for quantity field.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e-invoice-eu/core",
-	"version": "2.1.11",
+	"version": "2.1.12",
 	"description": "Generate e-invoices (E-Rechnung in German) conforming to EN16931 (Factur-X/ZUGFeRD, UBL, CII, XRechnung aka X-Rechnung) from LibreOffice Calc/Excel data or JSON. ",
 	"keywords": [
 		"factur-x",

--- a/packages/core/src/format/format-ubl.service.ts
+++ b/packages/core/src/format/format-ubl.service.ts
@@ -104,7 +104,11 @@ export class FormatUBLService
 							!key.includes(':InvoicePeriod') &&
 							!key.includes(':InvoiceDocumentReference')
 						) {
-							newKey = key.replace(':Invoice', ':CreditNote');
+							if (key.includes(':InvoicedQuantity')) {
+								newKey = key.replace(':Invoice', ':Credited');
+							} else {
+								newKey = key.replace(':Invoice', ':CreditNote');
+							}
 						}
 						newObj[newKey] = replaceInvoiceWithCreditNote(value);
 					}

--- a/packages/core/src/format/format-ubl.service.ts
+++ b/packages/core/src/format/format-ubl.service.ts
@@ -105,7 +105,7 @@ export class FormatUBLService
 							!key.includes(':InvoiceDocumentReference')
 						) {
 							if (key.includes(':InvoicedQuantity')) {
-								newKey = key.replace(':Invoice', ':Credited');
+								newKey = key.replace(':Invoiced', ':Credited');
 							} else {
 								newKey = key.replace(':Invoice', ':CreditNote');
 							}


### PR DESCRIPTION
There was a bug where the Quantity field was not correctly named in CreditNote.

The function replaced `Invoice` with `CreditNote` string, but there was exeption in naming for Quantity, where direct replacement did not worked.

It renamed the `InvoicedQuantity` to `CreditNotedQuantity` but as can be seen in the linked peppol docs, it had to be named to `CreditedQuantity`. This was only exemption in naming convenction to Credited as I could find.

https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-creditnote/cac-CreditNoteLine/cbc-CreditedQuantity/
https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-InvoiceLine/cbc-InvoicedQuantity/
 
See https://github.com/gflohr/e-invoice-eu/issues/238