### PR TITLE
downgrade global id in absence of a scheme

### DIFF
--- a/.changeset/puny-towns-design.md
+++ b/.changeset/puny-towns-design.md
@@ -1,0 +1,8 @@
+---
+'@e-invoice-eu/core': patch
+---
+
+Map buyer IDs correctly to CII.
+
+If a `schemeID` attribute is present, it is considered a global ID, otherwise
+a local ID. This is in line with the id maping of the delivery party.

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -1,19 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`CII regressions should downgrade buyer GlobalID to ID without a scheme (#465) 1`] = `
-"<?xml version="1.0" encoding="utf-8"?>
-<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
-	<rsm:SupplyChainTradeTransaction>
-		<ram:ApplicableHeaderTradeAgreement>
-			<ram:BuyerTradeParty>
-				<ram:ID>42</ram:ID>
-			</ram:BuyerTradeParty>
-		</ram:ApplicableHeaderTradeAgreement>
-	</rsm:SupplyChainTradeTransaction>
-</rsm:CrossIndustryInvoice>"
-`;
-
-exports[`CII regressions should fix #146 (missing TaxTotalAmount) 1`] = `
+exports[`CII regressions #146 missing TaxTotalAmount should fix add TaxTotalAmount 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
 	<rsm:SupplyChainTradeTransaction>
@@ -27,7 +14,7 @@ exports[`CII regressions should fix #146 (missing TaxTotalAmount) 1`] = `
 </rsm:CrossIndustryInvoice>"
 `;
 
-exports[`CII regressions should fix #310 (global ids) for IDs with an attribute 1`] = `
+exports[`CII regressions #310 adapt delivery party mapping depending on it attribute presence should fix #310 (global ids) for IDs with an attribute 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
 	<rsm:SupplyChainTradeTransaction>
@@ -40,20 +27,7 @@ exports[`CII regressions should fix #310 (global ids) for IDs with an attribute 
 </rsm:CrossIndustryInvoice>"
 `;
 
-exports[`CII regressions should keep buyer GlobalID to ID with a scheme (#465) 1`] = `
-"<?xml version="1.0" encoding="utf-8"?>
-<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
-	<rsm:SupplyChainTradeTransaction>
-		<ram:ApplicableHeaderTradeAgreement>
-			<ram:BuyerTradeParty>
-				<ram:GlobalID schemeID="0088">SE8765456787</ram:GlobalID>
-			</ram:BuyerTradeParty>
-		</ram:ApplicableHeaderTradeAgreement>
-	</rsm:SupplyChainTradeTransaction>
-</rsm:CrossIndustryInvoice>"
-`;
-
-exports[`CII regressions should not consider IDs w/o attribute as global (#310 global ids) 1`] = `
+exports[`CII regressions #310 adapt delivery party mapping depending on it attribute presence should not consider IDs w/o attribute as global (#310 global ids) 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
 	<rsm:SupplyChainTradeTransaction>
@@ -62,6 +36,32 @@ exports[`CII regressions should not consider IDs w/o attribute as global (#310 g
 				<ram:ID>around-the-corner</ram:ID>
 			</ram:ShipToTradeParty>
 		</ram:ApplicableHeaderTradeDelivery>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
+exports[`CII regressions #465 adapt buyer party mapping depending on it attribute presence should downgrade buyer GlobalID to ID without a scheme 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:BuyerTradeParty>
+				<ram:ID>42</ram:ID>
+			</ram:BuyerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
+exports[`CII regressions #465 adapt buyer party mapping depending on it attribute presence should keep buyer GlobalID to ID with a scheme 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:BuyerTradeParty>
+				<ram:GlobalID schemeID="0088">SE8765456787</ram:GlobalID>
+			</ram:BuyerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
 	</rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>"
 `;

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`CII regressions should downgrade buyer GlobalID to ID without a scheme (#465) 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:BuyerTradeParty>
+				<ram:ID>42</ram:ID>
+			</ram:BuyerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
 exports[`CII regressions should fix #146 (missing TaxTotalAmount) 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
@@ -23,6 +36,19 @@ exports[`CII regressions should fix #310 (global ids) for IDs with an attribute 
 				<ram:GlobalID schemeID="0088">83745498753497</ram:GlobalID>
 			</ram:ShipToTradeParty>
 		</ram:ApplicableHeaderTradeDelivery>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
+exports[`CII regressions should keep buyer GlobalID to ID with a scheme (#465) 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:BuyerTradeParty>
+				<ram:GlobalID schemeID="0088">SE8765456787</ram:GlobalID>
+			</ram:BuyerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
 	</rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>"
 `;

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -53,7 +53,7 @@ exports[`CII regressions #465 adapt buyer party mapping depending on it attribut
 </rsm:CrossIndustryInvoice>"
 `;
 
-exports[`CII regressions #465 adapt buyer party mapping depending on it attribute presence should keep buyer GlobalID to ID with a scheme 1`] = `
+exports[`CII regressions #465 adapt buyer party mapping depending on it attribute presence should keep buyer GlobalID with a scheme 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
 	<rsm:SupplyChainTradeTransaction>

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -87,109 +87,126 @@ describe('CII', () => {
 	});
 
 	describe('regressions', () => {
-		it('should fix #146 (missing TaxTotalAmount)', async () => {
-			const invoice: Invoice = {
-				'ubl:Invoice': {
-					'cac:TaxTotal': [
-						{
-							'cbc:TaxAmount': '20.00',
-							'cbc:TaxAmount@currencyID': 'BGN',
-						},
-					],
-					'cac:LegalMonetaryTotal': {
-						'cbc:LineExtensionAmount': '100.00',
-					},
-				},
-			} as unknown as Invoice;
-			const options = {} as InvoiceServiceOptions;
-			const xml = await service.generate(invoice, options);
-			expect(xml).toMatchSnapshot();
-		});
-
-		it('should fix #310 (global ids) for IDs with an attribute', async () => {
-			const invoice: Invoice = {
-				'ubl:Invoice': {
-					'cac:Delivery': {
-						'cac:DeliveryLocation': {
-							'cbc:ID': '83745498753497',
-							'cbc:ID@schemeID': '0088',
-						},
-					},
-				},
-			} as unknown as Invoice;
-			const options = {} as InvoiceServiceOptions;
-			const xml = await service.generate(invoice, options);
-			expect(xml).toMatchSnapshot();
-		});
-
-		it('should not consider IDs w/o attribute as global (#310 global ids)', async () => {
-			const invoice: Invoice = {
-				'ubl:Invoice': {
-					'cac:Delivery': {
-						'cac:DeliveryLocation': {
-							'cbc:ID': 'around-the-corner',
-						},
-					},
-				},
-			} as unknown as Invoice;
-			const options = {} as InvoiceServiceOptions;
-			const xml = await service.generate(invoice, options);
-			expect(xml).toMatchSnapshot();
-		});
-
-		it('maps BillingReference InvoiceDocumentReference to InvoiceReferencedDocument', async () => {
-			const invoice: Invoice = {
-				'ubl:Invoice': {
-					'cac:BillingReference': [
-						{
-							'cac:InvoiceDocumentReference': {
-								'cbc:ID': 'INV-123',
-								'cbc:IssueDate': '2025-12-31',
+		describe('#146 missing TaxTotalAmount', () => {
+			it('should fix add TaxTotalAmount', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:TaxTotal': [
+							{
+								'cbc:TaxAmount': '20.00',
+								'cbc:TaxAmount@currencyID': 'BGN',
 							},
-						},
-					],
-				},
-			} as unknown as Invoice;
-			const xml = await service.generate(invoice, {} as InvoiceServiceOptions);
-			expect(xml).toContain(
-				'<ram:IssuerAssignedID>INV-123</ram:IssuerAssignedID>',
-			);
-			expect(xml).toMatch(
-				/<qdt:DateTimeString format="102">\s*2025-12-31\s*<\/qdt:DateTimeString>/,
-			);
-		});
-
-		it('should downgrade buyer GlobalID to ID without a scheme (#465)', async () => {
-			const invoice: Invoice = {
-				'ubl:Invoice': {
-					'cac:AccountingCustomerParty': {
-						'cac:Party': {
-							'cac:PartyIdentification': {
-								'cbc:ID': '42',
-							},
+						],
+						'cac:LegalMonetaryTotal': {
+							'cbc:LineExtensionAmount': '100.00',
 						},
 					},
-				},
-			} as unknown as Invoice;
-			const xml = await service.generate(invoice, {} as InvoiceServiceOptions);
-			expect(xml).toMatchSnapshot();
+				} as unknown as Invoice;
+				const options = {} as InvoiceServiceOptions;
+				const xml = await service.generate(invoice, options);
+				expect(xml).toMatchSnapshot();
+			});
 		});
 
-		it('should keep buyer GlobalID to ID with a scheme (#465)', async () => {
-			const invoice: Invoice = {
-				'ubl:Invoice': {
-					'cac:AccountingCustomerParty': {
-						'cac:Party': {
-							'cac:PartyIdentification': {
-								'cbc:ID': 'SE8765456787',
+		describe('#310 adapt delivery party mapping depending on it attribute presence', () => {
+			it('should fix #310 (global ids) for IDs with an attribute', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:Delivery': {
+							'cac:DeliveryLocation': {
+								'cbc:ID': '83745498753497',
 								'cbc:ID@schemeID': '0088',
 							},
 						},
 					},
-				},
-			} as unknown as Invoice;
-			const xml = await service.generate(invoice, {} as InvoiceServiceOptions);
-			expect(xml).toMatchSnapshot();
+				} as unknown as Invoice;
+				const options = {} as InvoiceServiceOptions;
+				const xml = await service.generate(invoice, options);
+				expect(xml).toMatchSnapshot();
+			});
+
+			it('should not consider IDs w/o attribute as global (#310 global ids)', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:Delivery': {
+							'cac:DeliveryLocation': {
+								'cbc:ID': 'around-the-corner',
+							},
+						},
+					},
+				} as unknown as Invoice;
+				const options = {} as InvoiceServiceOptions;
+				const xml = await service.generate(invoice, options);
+				expect(xml).toMatchSnapshot();
+			});
+		});
+
+		describe('#455 map billing reference', () => {
+			it('maps BillingReference InvoiceDocumentReference to InvoiceReferencedDocument', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:BillingReference': [
+							{
+								'cac:InvoiceDocumentReference': {
+									'cbc:ID': 'INV-123',
+									'cbc:IssueDate': '2025-12-31',
+								},
+							},
+						],
+					},
+				} as unknown as Invoice;
+				const xml = await service.generate(
+					invoice,
+					{} as InvoiceServiceOptions,
+				);
+				expect(xml).toContain(
+					'<ram:IssuerAssignedID>INV-123</ram:IssuerAssignedID>',
+				);
+				expect(xml).toMatch(
+					/<qdt:DateTimeString format="102">\s*2025-12-31\s*<\/qdt:DateTimeString>/,
+				);
+			});
+		});
+
+		describe('#465 adapt buyer party mapping depending on it attribute presence', () => {
+			it('should downgrade buyer GlobalID to ID without a scheme', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:AccountingCustomerParty': {
+							'cac:Party': {
+								'cac:PartyIdentification': {
+									'cbc:ID': '42',
+								},
+							},
+						},
+					},
+				} as unknown as Invoice;
+				const xml = await service.generate(
+					invoice,
+					{} as InvoiceServiceOptions,
+				);
+				expect(xml).toMatchSnapshot();
+			});
+
+			it('should keep buyer GlobalID to ID with a scheme', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:AccountingCustomerParty': {
+							'cac:Party': {
+								'cac:PartyIdentification': {
+									'cbc:ID': 'SE8765456787',
+									'cbc:ID@schemeID': '0088',
+								},
+							},
+						},
+					},
+				} as unknown as Invoice;
+				const xml = await service.generate(
+					invoice,
+					{} as InvoiceServiceOptions,
+				);
+				expect(xml).toMatchSnapshot();
+			});
 		});
 	});
 });

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -171,7 +171,7 @@ describe('CII', () => {
 					'<ram:IssuerAssignedID>INV-123</ram:IssuerAssignedID>',
 				);
 				expect(xml).toMatch(
-					/<qdt:DateTimeString format="102">\s*2025-12-31\s*<\/qdt:DateTimeString>/,
+					/<qdt:DateTimeString format="102">\s*20251231\s*<\/qdt:DateTimeString>/,
 				);
 			});
 		});

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -122,6 +122,10 @@ describe('CII', () => {
 				} as unknown as Invoice;
 				const options = {} as InvoiceServiceOptions;
 				const xml = await service.generate(invoice, options);
+				expect(xml).toContain(
+					'<ram:GlobalID schemeID="0088">83745498753497</ram:GlobalID>',
+				);
+				expect(xml).not.toContain('<ram:ID>83745498753497</ram:ID>');
 				expect(xml).toMatchSnapshot();
 			});
 
@@ -137,6 +141,10 @@ describe('CII', () => {
 				} as unknown as Invoice;
 				const options = {} as InvoiceServiceOptions;
 				const xml = await service.generate(invoice, options);
+				expect(xml).toContain('<ram:ID>around-the-corner</ram:ID>');
+				expect(xml).not.toContain(
+					'<ram:GlobalID>around-the-corner</ram:GlobalID>',
+				);
 				expect(xml).toMatchSnapshot();
 			});
 		});
@@ -185,6 +193,8 @@ describe('CII', () => {
 					invoice,
 					{} as InvoiceServiceOptions,
 				);
+				expect(xml).toContain('<ram:ID>42</ram:ID>');
+				expect(xml).not.toContain('<ram:GlobalID>42</ram:GlobalID>');
 				expect(xml).toMatchSnapshot();
 			});
 
@@ -205,6 +215,10 @@ describe('CII', () => {
 					invoice,
 					{} as InvoiceServiceOptions,
 				);
+				expect(xml).toContain(
+					'<ram:GlobalID schemeID="0088">SE8765456787</ram:GlobalID>',
+				);
+				expect(xml).not.toContain('<ram:ID>SE8765456787</ram:ID>');
 				expect(xml).toMatchSnapshot();
 			});
 		});

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -188,7 +188,7 @@ describe('CII', () => {
 				expect(xml).toMatchSnapshot();
 			});
 
-			it('should keep buyer GlobalID to ID with a scheme', async () => {
+			it('should keep buyer GlobalID with a scheme', async () => {
 				const invoice: Invoice = {
 					'ubl:Invoice': {
 						'cac:AccountingCustomerParty': {

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -158,5 +158,38 @@ describe('CII', () => {
 				/<qdt:DateTimeString format="102">\s*2025-12-31\s*<\/qdt:DateTimeString>/,
 			);
 		});
+
+		it('should downgrade buyer GlobalID to ID without a scheme (#465)', async () => {
+			const invoice: Invoice = {
+				'ubl:Invoice': {
+					'cac:AccountingCustomerParty': {
+						'cac:Party': {
+							'cac:PartyIdentification': {
+								'cbc:ID': '42',
+							},
+						},
+					},
+				},
+			} as unknown as Invoice;
+			const xml = await service.generate(invoice, {} as InvoiceServiceOptions);
+			expect(xml).toMatchSnapshot();
+		});
+
+		it('should keep buyer GlobalID to ID with a scheme (#465)', async () => {
+			const invoice: Invoice = {
+				'ubl:Invoice': {
+					'cac:AccountingCustomerParty': {
+						'cac:Party': {
+							'cac:PartyIdentification': {
+								'cbc:ID': 'SE8765456787',
+								'cbc:ID@schemeID': '0088',
+							},
+						},
+					},
+				},
+			} as unknown as Invoice;
+			const xml = await service.generate(invoice, {} as InvoiceServiceOptions);
+			expect(xml).toMatchSnapshot();
+		});
 	});
 });

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -434,6 +434,7 @@ const cacBillingReference: Transformation[] = [
 	},
 	{
 		type: 'string',
+		subtype: 'DateTimeString',
 		src: ['cac:InvoiceDocumentReference', 'cbc:IssueDate'],
 		dest: ['ram:FormattedIssueDateTime', 'qdt:DateTimeString'],
 		fxProfileMask: FX_MASK_BASIC_WL,

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -1715,25 +1715,14 @@ export class FormatCIIService
 		}
 
 		// Same as above.
-		const shipTo1 =
-			cii['rsm:CrossIndustryInvoice']?.['ram:ApplicableHeaderTradeAgreement']?.[
-				'ram:ShipToTradeParty'
-			];
-
-		if (shipTo1?.['ram:GlobalID'] && !shipTo1['ram:GlobalID@schemeID']) {
-			shipTo1['ram:ID'] = shipTo1['ram:GlobalID'];
-			delete shipTo1['ram:GlobalID'];
-		}
-
-		// Same as above.
-		const shipTo2 =
+		const shipTo =
 			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
 				'ram:ApplicableHeaderTradeDelivery'
 			]?.['ram:ShipToTradeParty'];
 
-		if (shipTo2?.['ram:GlobalID'] && !shipTo2['ram:GlobalID@schemeID']) {
-			shipTo2['ram:ID'] = shipTo2['ram:GlobalID'];
-			delete shipTo2['ram:GlobalID'];
+		if (shipTo?.['ram:GlobalID'] && !shipTo['ram:GlobalID@schemeID']) {
+			shipTo['ram:ID'] = shipTo['ram:GlobalID'];
+			delete shipTo['ram:GlobalID'];
 		}
 
 		const supplierTaxRegistration =

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -1698,6 +1698,17 @@ export class FormatCIIService
 	private postProcess(cii: ObjectNode) {
 		// If the delivery location ID does not have a scheme, downgrade it from
 		// ram:GlobalID to ram:ID.
+		const buyerParty =
+			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
+				'ram:ApplicableHeaderTradeDelivery'
+			]?.['ram:BuyerTradeParty'];
+
+		if (buyerParty?.['ram:GlobalID'] && !buyerParty['ram:GlobalID@schemeID']) {
+			buyerParty['ram:ID'] = buyerParty['ram:GlobalID'];
+			delete buyerParty['ram:GlobalID'];
+		}
+
+		// Same as above.
 		const shipTo =
 			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
 				'ram:ApplicableHeaderTradeDelivery'

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -1699,9 +1699,9 @@ export class FormatCIIService
 		// If the delivery location ID does not have a scheme, downgrade it from
 		// ram:GlobalID to ram:ID.
 		const buyerParty =
-			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
-				'ram:ApplicableHeaderTradeDelivery'
-			]?.['ram:BuyerTradeParty'];
+			cii['rsm:CrossIndustryInvoice']?.['ram:ApplicableHeaderTradeAgreement']?.[
+				'ram:BuyerTradeParty'
+			];
 
 		if (buyerParty?.['ram:GlobalID'] && !buyerParty['ram:GlobalID@schemeID']) {
 			buyerParty['ram:ID'] = buyerParty['ram:GlobalID'];
@@ -1709,14 +1709,25 @@ export class FormatCIIService
 		}
 
 		// Same as above.
-		const shipTo =
+		const shipTo1 =
+			cii['rsm:CrossIndustryInvoice']?.['ram:ApplicableHeaderTradeAgreement']?.[
+				'ram:ShipToTradeParty'
+			];
+
+		if (shipTo1?.['ram:GlobalID'] && !shipTo1['ram:GlobalID@schemeID']) {
+			shipTo1['ram:ID'] = shipTo1['ram:GlobalID'];
+			delete shipTo1['ram:GlobalID'];
+		}
+
+		// Same as above.
+		const shipTo2 =
 			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
 				'ram:ApplicableHeaderTradeDelivery'
 			]?.['ram:ShipToTradeParty'];
 
-		if (shipTo?.['ram:GlobalID'] && !shipTo['ram:GlobalID@schemeID']) {
-			shipTo['ram:ID'] = shipTo['ram:GlobalID'];
-			delete shipTo['ram:GlobalID'];
+		if (shipTo2?.['ram:GlobalID'] && !shipTo2['ram:GlobalID@schemeID']) {
+			shipTo2['ram:ID'] = shipTo2['ram:GlobalID'];
+			delete shipTo2['ram:GlobalID'];
 		}
 
 		const supplierTaxRegistration =

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -717,7 +717,13 @@ export const cacAccountingCustomerParty: Transformation[] = [
 	{
 		type: 'string',
 		src: ['cac:PartyIdentification', 'cbc:ID'],
-		dest: ['ram:ID'],
+		dest: ['ram:GlobalID'],
+		fxProfileMask: FX_MASK_BASIC_WL,
+	},
+	{
+		type: 'string',
+		src: ['cac:PartyIdentification', 'cbc:ID@schemeID'],
+		dest: ['ram:GlobalID@schemeID'],
 		fxProfileMask: FX_MASK_BASIC_WL,
 	},
 	{
@@ -1699,9 +1705,9 @@ export class FormatCIIService
 		// If the delivery location ID does not have a scheme, downgrade it from
 		// ram:GlobalID to ram:ID.
 		const buyerParty =
-			cii['rsm:CrossIndustryInvoice']?.['ram:ApplicableHeaderTradeAgreement']?.[
-				'ram:BuyerTradeParty'
-			];
+			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
+				'ram:ApplicableHeaderTradeAgreement'
+			]?.['ram:BuyerTradeParty'];
 
 		if (buyerParty?.['ram:GlobalID'] && !buyerParty['ram:GlobalID@schemeID']) {
 			buyerParty['ram:ID'] = buyerParty['ram:GlobalID'];


### PR DESCRIPTION
This fixes #465.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CII party identifier handling refined: identifiers prefer GlobalID when a scheme is present; buyer and ship-to parties are downgraded to local IDs when no scheme is provided. Billing reference dates are emitted as datetime strings (format 102).

* **Tests**
  * Regression suite reorganized and expanded to verify buyer-party mapping (with/without scheme), billing reference emission, issuer-assigned ID, and IssueDate datetime formatting.

* **Chores**
  * Patch release note added documenting the buyer ID mapping fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->