### PR TITLE
Fix three CII mapping errors in format-cii.service.ts

### DIFF
--- a/.changeset/odd-jeans-wink.md
+++ b/.changeset/odd-jeans-wink.md
@@ -1,0 +1,7 @@
+---
+"@e-invoice-eu/core": patch
+---
+
+* ReceivableSpecifiedTradeAccountingAccount no longer placed outside ApplicableHeaderTradeSettlement
+* Remove @currencyID on Amount elements (forbidden by CII-DT-031)
+* Fix CII mapping for payee identifier (BT-60)

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -293,15 +293,8 @@ const cacPrice: Transformation = {
 					dest: ['ram:AppliedTradeAllowanceCharge', 'ram:ActualAmount'],
 					fxProfileMask: FX_MASK_EN16931,
 				},
-				{
-					type: 'string',
-					src: ['cbc:Amount@currencyID'],
-					dest: [
-						'ram:AppliedTradeAllowanceCharge',
-						'ram:ActualAmount@currencyID',
-					],
-					fxProfileMask: FX_MASK_EN16931,
-				},
+				// currencyID omitted: CII-DT-031 forbids @currencyID on
+				// Amount elements (except TaxTotalAmount).
 			],
 			fxProfileMask: FX_MASK_EN16931,
 		},
@@ -370,22 +363,12 @@ const cacInvoiceLineAllowanceCharge: Transformation = {
 			dest: ['ram:BasisAmount'],
 			fxProfileMask: FX_MASK_BASIC,
 		},
-		{
-			type: 'string',
-			src: ['cbc:BaseAmount@currencyID'],
-			dest: ['ram:BasisAmount@currencyID'],
-			fxProfileMask: FX_MASK_BASIC,
-		},
+		// currencyID omitted on BasisAmount and ActualAmount:
+		// CII-DT-031 forbids @currencyID on Amount elements (except TaxTotalAmount).
 		{
 			type: 'string',
 			src: ['cbc:Amount'],
 			dest: ['ram:ActualAmount'],
-			fxProfileMask: FX_MASK_BASIC,
-		},
-		{
-			type: 'string',
-			src: ['cbc:Amount@currencyID'],
-			dest: ['ram:ActualAmount@currencyID'],
 			fxProfileMask: FX_MASK_BASIC,
 		},
 		{
@@ -1515,15 +1498,9 @@ export const ublInvoice: Transformation = {
 					],
 					fxProfileMask: FX_MASK_BASIC_WL,
 				},
-				{
-					type: 'string',
-					src: ['cac:PayeeParty', 'cac:PartyIdentification', 'cbc:ID'],
-					dest: [
-						'ram:ApplicableHeaderTradeSettlement',
-						'ram:CreditorReferenceID',
-					],
-					fxProfileMask: FX_MASK_BASIC_WL,
-				},
+				// BT-60 (Payee identifier) is mapped inside cacPayeeParty
+				// as ram:PayeeTradeParty/ram:ID. The previous mapping here
+				// incorrectly placed it in ram:CreditorReferenceID (BT-90).
 				{
 					type: 'string',
 					src: ['cac:PaymentMeans[0]', 'cbc:PaymentID'],
@@ -1639,7 +1616,11 @@ export const ublInvoice: Transformation = {
 				{
 					type: 'string',
 					src: ['cbc:AccountingCost'],
-					dest: ['ram:ReceivableSpecifiedTradeAccountingAccount', 'ram:ID'],
+					dest: [
+						'ram:ApplicableHeaderTradeSettlement',
+						'ram:ReceivableSpecifiedTradeAccountingAccount',
+						'ram:ID',
+					],
 					fxProfileMask: FX_MASK_BASIC_WL,
 				},
 			],


### PR DESCRIPTION
1. ReceivableSpecifiedTradeAccountingAccount: add missing ram:ApplicableHeaderTradeSettlement parent in dest path. The element was placed as a sibling instead of a child.

2. Remove @currencyID mappings on AppliedTradeAllowanceCharge/ActualAmount, SpecifiedTradeAllowanceCharge/BasisAmount, and SpecifiedTradeAllowanceCharge/ActualAmount. CII-DT-031 forbids @currencyID on all Amount elements except TaxTotalAmount.

3. Remove duplicate mapping of PayeeParty/PartyIdentification/cbc:ID (BT-60) to ram:CreditorReferenceID (BT-90). BT-60 is already correctly mapped inside cacPayeeParty as ram:PayeeTradeParty/ram:ID. The incorrect mapping caused XRechnung BR-DE-23-b/30/31 failures when a payee identifier coexisted with credit transfer payment means.

Ref: https://github.com/gflohr/e-invoice-eu/issues/478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed incorrect currency attribute emission on amount fields to comply with CII rules.
  * Fixed creditor/payee reference at document level so the correct identifier is used.
  * Ensured accounting cost is emitted under the proper header hierarchy so charges appear in the right section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->