### PR TITLE
undone changing module to nodenext

### DIFF
--- a/.changeset/bumpy-impalas-rhyme.md
+++ b/.changeset/bumpy-impalas-rhyme.md
@@ -1,0 +1,8 @@
+---
+'@e-invoice-eu/core': patch
+---
+
+Move module type back to esnext.
+
+Setting `module` and `moduleResolution` to NodeNext broke the build
+(see #489).

--- a/.trivyignore
+++ b/.trivyignore
@@ -15,3 +15,8 @@ CVE-2026-31802
 # Date: 2026-04-02
 # Vulnerability in picomatch. This is part of npm but npm is not used.
 CVE-2026-33671
+
+# Date: 2026-04-04
+# Vulnerability in libinput-libs. This seems to be a false positive.
+# The library is not present in the image.
+CVE-2026-35093

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,8 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"module": "nodenext",
-		"moduleResolution": "nodenext",
+		"module": "esnext",
 		"typeRoots": ["node_modules/@types"],
 		"rootDir": "./src"
 	}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"module": "esnext",
+		"moduleResolution": "bundler",
 		"typeRoots": ["node_modules/@types"],
 		"rootDir": "./src"
 	}


### PR DESCRIPTION
This fixes #489.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript build configuration to improve module compatibility.
* **Security**
  * Added an ignored vulnerability entry to the scanner configuration for a likely false positive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->