### PR TITLE
remove chmod

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -34,7 +34,7 @@
 		"e-invoice-eu": "dist/index.js"
 	},
 	"scripts": {
-		"build": "rimraf ./dist && tsc --project tsconfig.build.json && chmod +x dist/index.js",
+		"build": "rimraf ./dist && tsc --project tsconfig.build.json",
 		"prebuild": "node ./write-package.mjs >src/package.ts",
 		"check:clean": "../../check-clean",
 		"format": "prettier --write 'src/**/*.ts' *.mjs *.json",


### PR DESCRIPTION
Not needed, and it does not work on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the CLI build process by removing the filesystem permission modification step from the build script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->