### PR TITLE
map seller party identification to CII

### DIFF
--- a/.changeset/strict-kiwis-rhyme.md
+++ b/.changeset/strict-kiwis-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@e-invoice-eu/core': patch
+---
+
+Map seller party identifications to CII.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,23 +8,25 @@ assignees: ''
 
 **Describe the Bug**
 
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 
-Steps to reproduce the behavior:
+<!-- Steps to reproduce the behavior:
 
 1. ...
 2. ...
 3. ...
 4. See error
+-->
 
 **Expected behavior**
 
-A clear and concise description of what you expected to happen.  If you report
-a violation of a standard, please add a reference to the standard, and the
-exact rule that is violated.
+<!-- A clear and concise description of what you expected to happen.  If you
+report a violation of a standard, please add a reference to the standard, and
+the exact rule that is violated. -->
 
 **Additional Context**
 
-Add any other context about the problem here, for example validation reports.
+<!-- Add any other context about the problem here, for example validation
+reports. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,5 +5,5 @@ title: ''
 labels: ''
 assignees: ''
 ---
-Please suggest *only one feature request* per issue! Please cite applicable
-standards if the feature request is related to a standard!
+<!-- Please suggest *only one feature request* per issue! Please cite
+     applicable standards if the feature request is related to a standard! -->

--- a/contrib/data/default-invoice.json
+++ b/contrib/data/default-invoice.json
@@ -18,6 +18,15 @@
 			"cac:Party": {
 				"cbc:EndpointID": "DE202526944",
 				"cbc:EndpointID@schemeID": "9930",
+				"cac:PartyIdentification": [
+					{
+						"cbc:ID": "42"
+					},
+					{
+						"cbc:ID": "5060012349998",
+						"cbc:ID@schemeID": "0088"
+					}
+				],
 				"cac:PartyName": {
 					"cbc:Name": "Acme Ltd."
 				},

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -66,6 +66,25 @@ exports[`CII regressions #465 adapt buyer party mapping depending on it attribut
 </rsm:CrossIndustryInvoice>"
 `;
 
+exports[`CII regressions #490 adapt seller party mappings depending on it attribute presence should map seller ids in a context-depending manner 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:SellerTradeParty>
+				<ram:ID>42</ram:ID>
+				<ram:ID>well known</ram:ID>
+				<ram:GlobalID schemeID="0088">5060012349998</ram:GlobalID>
+				<ram:GlobalID schemeID="0044">abcdefxyz</ram:GlobalID>
+				<ram:SpecifiedLegalOrganization>
+					<ram:TradingBusinessName>Acme Ltd.</ram:TradingBusinessName>
+				</ram:SpecifiedLegalOrganization>
+			</ram:SellerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
 exports[`CII should convert arrays 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -222,5 +222,61 @@ describe('CII', () => {
 				expect(xml).toMatchSnapshot();
 			});
 		});
+
+		describe('#490 adapt seller party mappings depending on it attribute presence', () => {
+			it('should map seller ids in a context-depending manner', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:AccountingSupplierParty': {
+							'cac:Party': {
+								'cac:PartyIdentification': [
+									// Those will become global IDs.
+									{
+										'cbc:ID': '5060012349998',
+										'cbc:ID@schemeID': '0088',
+									},
+									{
+										'cbc:ID': 'abcdefxyz',
+										'cbc:ID@schemeID': '0044',
+									},
+									// And those will remain a local IDs.
+									{
+										'cbc:ID': '42',
+									},
+									{
+										'cbc:ID': 'well known',
+									},
+								],
+								// Make sure that this will come last in the
+								// XML output.
+								'cac:PartyName': {
+									'cbc:Name': 'Acme Ltd.',
+								},
+							},
+						},
+					},
+				} as unknown as Invoice;
+				const xml = await service.generate(
+					invoice,
+					{} as InvoiceServiceOptions,
+				);
+				expect(xml).toContain('<ram:ID>42</ram:ID>');
+				expect(xml).not.toContain('>42</ram:GlobalID>');
+				expect(xml).toContain('<ram:ID>well known</ram:ID>');
+				expect(xml).not.toContain('>well known</ram:GlobalID>');
+				expect(xml).not.toContain('<ram:ID schemeID');
+				expect(xml).toContain(
+					'<ram:GlobalID schemeID="0088">5060012349998</ram:GlobalID>',
+				);
+				expect(xml).not.toContain('>5060012349998</ram:ID>');
+				expect(xml).toContain(
+					'<ram:GlobalID schemeID="0044">abcdefxyz</ram:GlobalID>',
+				);
+				expect(xml).not.toContain('>abcdefxyz</ram:ID>');
+				// The snapshot test ensures that all local IDs precede the
+				// global IDs.
+				expect(xml).toMatchSnapshot();
+			});
+		});
 	});
 });

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -239,7 +239,7 @@ describe('CII', () => {
 										'cbc:ID': 'abcdefxyz',
 										'cbc:ID@schemeID': '0044',
 									},
-									// And those will remain a local IDs.
+									// And those will remain local IDs.
 									{
 										'cbc:ID': '42',
 									},

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -598,20 +598,30 @@ export const cacSupplierPartyTaxScheme: Transformation[] = [
 	},
 ];
 
+export const cacSupplierPartyIdentification: Transformation[] = [
+	{
+		type: 'string',
+		src: ['cbc:ID'],
+		// This may be downgraded to ram:ID in the post-processing.
+		dest: ['ram:GlobalID'],
+		fxProfileMask: FX_MASK_BASIC_WL,
+	},
+	{
+		type: 'string',
+		src: ['cbc:ID@schemeID'],
+		dest: ['ram:GlobalID@schemeID'],
+		fxProfileMask: FX_MASK_BASIC_WL,
+	},
+];
+
 export const cacAccountingSupplierParty: Transformation[] = [
 	{
 		type: 'array',
-		src: [],
-		dest: [],
-		children: [
-			{
-				type: 'string',
-				src: ['cac:PartyIdentification', 'cbc:ID'],
-				dest: ['ram:ID'],
-				fxProfileMask: FX_MASK_BASIC_WL,
-			},
-		],
-		fxProfileMask: FX_MASK_MINIMUM,
+		src: ['cac:PartyIdentification'],
+		// This layer gets removed in the post-processing.
+		dest: ['dummy:PartyIdentification'],
+		children: cacSupplierPartyIdentification,
+		fxProfileMask: FX_MASK_BASIC_WL,
 	},
 	{
 		type: 'string',
@@ -1684,6 +1694,8 @@ export class FormatCIIService
 	}
 
 	private postProcess(cii: ObjectNode) {
+		this.postProcessSellerTradeParty(cii);
+
 		// If the delivery location ID does not have a scheme, downgrade it from
 		// ram:GlobalID to ram:ID.
 		const buyerParty =
@@ -1725,6 +1737,70 @@ export class FormatCIIService
 				supplierTaxRegistration['ram:ID@schemeID'] = 'FC';
 			}
 		}
+	}
+
+	private postProcessSellerTradeParty(cii: ObjectNode) {
+		const sellerParty =
+			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
+				'ram:ApplicableHeaderTradeAgreement'
+			]?.['ram:SellerTradeParty'];
+
+		if (!sellerParty) return; // Can happen in tests.
+
+		type PartyIdentification = {
+			'ram:GlobalID': string;
+			'ram:GlobalID@schemeID'?: string;
+		};
+		const partyIdentifications: PartyIdentification[] =
+			sellerParty['dummy:PartyIdentification'];
+		if (!partyIdentifications) return;
+
+		delete sellerParty['dummy:PartyIdentification'];
+		const localIDs: string[] = [];
+		type GlobalID = {
+			'#': string;
+			'ram:GlobalID@schemeID': string;
+		};
+		const globalIDs: GlobalID[] = [];
+
+		for (const pi of partyIdentifications) {
+			if (pi['ram:GlobalID@schemeID']) {
+				globalIDs.push({
+					'#': pi['ram:GlobalID'],
+					'ram:GlobalID@schemeID': pi['ram:GlobalID@schemeID'],
+				});
+			} else {
+				localIDs.push(pi['ram:GlobalID']);
+			}
+		}
+
+		// Rebuild sellerParty with ram:ID and ram:GlobalID first.
+		const orderedSellerParty: ObjectNode = {};
+
+		// Add local IDs first.
+		if (localIDs.length) {
+			orderedSellerParty['ram:ID'] = localIDs;
+		}
+
+		// Add global IDs.
+		if (globalIDs.length) {
+			orderedSellerParty['ram:GlobalID'] = globalIDs.map(gid => ({
+				'#': gid['#'],
+				'@schemeID': gid['ram:GlobalID@schemeID'],
+			}));
+		}
+
+		// Copy remaining original properties in their original order.
+		for (const key of Object.keys(sellerParty)) {
+			orderedSellerParty[key] = sellerParty[key];
+		}
+
+		// Replace the sellerParty object with the ordered one
+		const parent =
+			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
+				'ram:ApplicableHeaderTradeAgreement'
+			];
+		parent['ram:SellerTradeParty'] = orderedSellerParty;
 	}
 
 	private convert(


### PR DESCRIPTION
This fixes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mapping of seller party identifications to CII format, ensuring identifications are correctly processed with or without scheme attributes.

* **Tests**
  * Added comprehensive test coverage for seller party identifier mapping validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->