### PR TITLE
allow invoice data post-processing

### DIFF
--- a/.changeset/frank-dogs-hunt.md
+++ b/.changeset/frank-dogs-hunt.md
@@ -5,7 +5,7 @@
 Allow post-processing of invoice data before XML is rendered.
 
 See the API documentation for
-[`InvoiceServiceOptions`](https://gflohr.github.io/e-invoice-eu/api-docs/types/InvoiceServiceOptions.html#nowarnings).
+[`InvoiceServiceOptions`](https://gflohr.github.io/e-invoice-eu/api-docs/types/InvoiceServiceOptions.html#postprocessor).
 
 It is not planned to port this feature to the command-line tool or the REST
 API. For those interfaces, you can easily run the generated XML through some

--- a/.changeset/frank-dogs-hunt.md
+++ b/.changeset/frank-dogs-hunt.md
@@ -1,0 +1,16 @@
+---
+'@e-invoice-eu/core': patch
+---
+
+Allow post-processing of invoice data before XML is rendered.
+
+See the API documentation for
+[`InvoiceServiceOptions`](https://gflohr.github.io/e-invoice-eu/api-docs/types/InvoiceServiceOptions.html#nowarnings).
+
+It is not planned to port this feature to the command-line tool or the REST
+API. For those interfaces, you can easily run the generated XML through some
+XSL stylesheet.
+
+For the hybrid formats Factur-X resp. ZUGFeRD, this will include an invocation
+of `pdftk` or a similar tool for extracting the attachment, deleting it, and
+adding it again.

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -7,7 +7,11 @@ exports[`CII post-processing should append default notes to the invoice notes 1`
 		<ram:ID>1234567890</ram:ID>
 		<ram:IncludedNote>
 			<ram:Content>Please send complaints to devnull@us.com</ram:Content>
+		</ram:IncludedNote>
+		<ram:IncludedNote>
 			<ram:Content>Buy a dozen donuts at the Kwik-E-Mart and instantly becomeHomer-level happy—guaranteed to make your cat ignore you!</ram:Content>
+		</ram:IncludedNote>
+		<ram:IncludedNote>
 			<ram:Content>Order Bart's Skateboard Deluxe 3000 from the Simpson Garagebecause it's the only board that survives a launch overGrandpa's dentures!</ram:Content>
 		</ram:IncludedNote>
 	</rsm:ExchangedDocument>

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -9,10 +9,10 @@ exports[`CII post-processing should append default notes to the invoice notes 1`
 			<ram:Content>Please send complaints to devnull@us.com</ram:Content>
 		</ram:IncludedNote>
 		<ram:IncludedNote>
-			<ram:Content>Buy a dozen donuts at the Kwik-E-Mart and instantly becomeHomer-level happy—guaranteed to make your cat ignore you!</ram:Content>
+			<ram:Content>Buy a dozen donuts at the Kwik-E-Mart and instantly become Homer-level happy—guaranteed to make your cat ignore you!</ram:Content>
 		</ram:IncludedNote>
 		<ram:IncludedNote>
-			<ram:Content>Order Bart's Skateboard Deluxe 3000 from the Simpson Garagebecause it's the only board that survives a launch overGrandpa's dentures!</ram:Content>
+			<ram:Content>Order Bart's Skateboard Deluxe 3000 from the Simpson Garage because it's the only board that survives a launch over Grandpa's dentures!</ram:Content>
 		</ram:IncludedNote>
 	</rsm:ExchangedDocument>
 </rsm:CrossIndustryInvoice>"

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`CII post-processing should append default notes to the invoice notes 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:ExchangedDocument>
+		<ram:ID>1234567890</ram:ID>
+		<ram:IncludedNote>
+			<ram:Content>Please send complaints to devnull@us.com</ram:Content>
+			<ram:Content>Buy a dozen donuts at the Kwik-E-Mart and instantly becomeHomer-level happy—guaranteed to make your cat ignore you!</ram:Content>
+			<ram:Content>Order Bart's Skateboard Deluxe 3000 from the Simpson Garagebecause it's the only board that survives a launch overGrandpa's dentures!</ram:Content>
+		</ram:IncludedNote>
+	</rsm:ExchangedDocument>
+</rsm:CrossIndustryInvoice>"
+`;
+
 exports[`CII regressions #146 missing TaxTotalAmount should fix add TaxTotalAmount 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">

--- a/packages/core/src/format/__snapshots__/format-ubl.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-ubl.service.spec.ts.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`UBL post-processing should append default notes to credit-note notes 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<CreditNote xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:ID>1234567890</cbc:ID>
+	<cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
+	<cbc:Note>Please send complaints to devnull@us.com</cbc:Note>
+	<cbc:Note>Buy a dozen donuts at the Kwik-E-Mart and instantly becomeHomer-level happy—guaranteed to make your cat ignore you!</cbc:Note>
+	<cbc:Note>Order Bart's Skateboard Deluxe 3000 from the Simpson Garagebecause it's the only board that survives a launch overGrandpa's dentures!</cbc:Note>
+</CreditNote>"
+`;
+
+exports[`UBL post-processing should append default notes to invoice notes 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:ID>1234567890</cbc:ID>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:Note>Please send complaints to devnull@us.com</cbc:Note>
+	<cbc:Note>Buy a dozen donuts at the Kwik-E-Mart and instantly becomeHomer-level happy—guaranteed to make your cat ignore you!</cbc:Note>
+	<cbc:Note>Order Bart's Skateboard Deluxe 3000 from the Simpson Garagebecause it's the only board that survives a launch overGrandpa's dentures!</cbc:Note>
+</Invoice>"
+`;
+
 exports[`UBL should attach attachments 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">

--- a/packages/core/src/format/__snapshots__/format-ubl.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-ubl.service.spec.ts.snap
@@ -6,8 +6,8 @@ exports[`UBL post-processing should append default notes to credit-note notes 1`
 	<cbc:ID>1234567890</cbc:ID>
 	<cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
 	<cbc:Note>Please send complaints to devnull@us.com</cbc:Note>
-	<cbc:Note>Buy a dozen donuts at the Kwik-E-Mart and instantly becomeHomer-level happy—guaranteed to make your cat ignore you!</cbc:Note>
-	<cbc:Note>Order Bart's Skateboard Deluxe 3000 from the Simpson Garagebecause it's the only board that survives a launch overGrandpa's dentures!</cbc:Note>
+	<cbc:Note>Buy a dozen donuts at the Kwik-E-Mart and instantly become Homer-level happy—guaranteed to make your cat ignore you!</cbc:Note>
+	<cbc:Note>Order Bart's Skateboard Deluxe 3000 from the Simpson Garage because it's the only board that survives a launch over Grandpa's dentures!</cbc:Note>
 </CreditNote>"
 `;
 
@@ -17,8 +17,8 @@ exports[`UBL post-processing should append default notes to invoice notes 1`] = 
 	<cbc:ID>1234567890</cbc:ID>
 	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
 	<cbc:Note>Please send complaints to devnull@us.com</cbc:Note>
-	<cbc:Note>Buy a dozen donuts at the Kwik-E-Mart and instantly becomeHomer-level happy—guaranteed to make your cat ignore you!</cbc:Note>
-	<cbc:Note>Order Bart's Skateboard Deluxe 3000 from the Simpson Garagebecause it's the only board that survives a launch overGrandpa's dentures!</cbc:Note>
+	<cbc:Note>Buy a dozen donuts at the Kwik-E-Mart and instantly become Homer-level happy—guaranteed to make your cat ignore you!</cbc:Note>
+	<cbc:Note>Order Bart's Skateboard Deluxe 3000 from the Simpson Garage because it's the only board that survives a launch over Grandpa's dentures!</cbc:Note>
 </Invoice>"
 `;
 

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -3,6 +3,7 @@ import { Invoice } from '@e-invoice-eu/core';
 import { FormatCIIService } from './format-cii.service';
 import { InvoiceServiceOptions } from '../invoice/invoice.service';
 import { Logger } from '../logger.interface';
+import { ExpandObject } from 'xmlbuilder2/lib/interfaces';
 
 describe('CII', () => {
 	let service: FormatCIIService;
@@ -84,6 +85,42 @@ describe('CII', () => {
 		const options = {} as InvoiceServiceOptions;
 		const xml = await service.generate(invoice, options);
 		expect(xml).toMatchSnapshot();
+	});
+
+	describe('post-processing', () => {
+		const defaultNotes = [
+			'Buy a dozen donuts at the Kwik-E-Mart and instantly become'
+			+ 'Homer-level happy—guaranteed to make your cat ignore you!',
+			'Order Bart\'s Skateboard Deluxe 3000 from the Simpson Garage'
+			+ 'because it\'s the only board that survives a launch over'
+			+ 'Grandpa\'s dentures!'
+		];
+
+		const postProcessor = (data: ExpandObject) => {
+			const notes = data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']?.
+				['ram:IncludedNote']?.['ram:Content'];
+
+			if (notes) {
+				notes.push(...defaultNotes);
+			} else {
+				data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']['ram:Content'] = [...defaultNotes];
+			}
+		};
+
+		it('should append default notes to the invoice notes', async () => {
+			const invoice: Invoice = {
+				'ubl:Invoice': {
+					'cbc:ID': '1234567890',
+					'cbc:Note': ['Please send complaints to devnull@us.com'],
+				},
+			} as unknown as Invoice;
+			const options = {
+				postProcessor
+			} as InvoiceServiceOptions;
+
+			const xml = await service.generate(invoice, options);
+			expect(xml).toMatchSnapshot();
+		});
 	});
 
 	describe('regressions', () => {

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -90,10 +90,10 @@ describe('CII', () => {
 	describe('post-processing', () => {
 		const defaultNotes = [
 			'Buy a dozen donuts at the Kwik-E-Mart and instantly become' +
-				'Homer-level happy—guaranteed to make your cat ignore you!',
+				' Homer-level happy—guaranteed to make your cat ignore you!',
 			"Order Bart's Skateboard Deluxe 3000 from the Simpson Garage" +
-				"because it's the only board that survives a launch over" +
-				"Grandpa's dentures!",
+				" because it's the only board that survives a launch over" +
+				" Grandpa's dentures!",
 		];
 
 		const postProcessor = (data: ExpandObject) => {

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -89,21 +89,47 @@ describe('CII', () => {
 
 	describe('post-processing', () => {
 		const defaultNotes = [
-			'Buy a dozen donuts at the Kwik-E-Mart and instantly become'
-			+ 'Homer-level happy—guaranteed to make your cat ignore you!',
-			'Order Bart\'s Skateboard Deluxe 3000 from the Simpson Garage'
-			+ 'because it\'s the only board that survives a launch over'
-			+ 'Grandpa\'s dentures!'
+			'Buy a dozen donuts at the Kwik-E-Mart and instantly become' +
+				'Homer-level happy—guaranteed to make your cat ignore you!',
+			"Order Bart's Skateboard Deluxe 3000 from the Simpson Garage" +
+				"because it's the only board that survives a launch over" +
+				"Grandpa's dentures!",
 		];
 
 		const postProcessor = (data: ExpandObject) => {
-			const notes = data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']?.
-				['ram:IncludedNote']?.['ram:Content'];
-
-			if (notes) {
-				notes.push(...defaultNotes);
+			if (
+				data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+					'ram:IncludedNote'
+				]
+			) {
+				if (
+					!Array.isArray(
+						data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+							'ram:IncludedNote'
+						],
+					)
+				) {
+					data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+						'ram:IncludedNote'
+					] = [
+						data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+							'ram:IncludedNote'
+						],
+					];
+				}
 			} else {
-				data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']['ram:Content'] = [...defaultNotes];
+				data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+					'ram:IncludedNote'
+				] = [];
+			}
+
+			const notes =
+				data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument'][
+					'ram:IncludedNote'
+				];
+
+			for (const note of defaultNotes) {
+				notes.push({ 'ram:Content': note });
 			}
 		};
 
@@ -115,7 +141,7 @@ describe('CII', () => {
 				},
 			} as unknown as Invoice;
 			const options = {
-				postProcessor
+				postProcessor,
 			} as InvoiceServiceOptions;
 
 			const xml = await service.generate(invoice, options);

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -1687,7 +1687,7 @@ export class FormatCIIService
 		this.postProcess(cii);
 
 		if (options.postProcessor) {
-			options.postProcessor(cii);
+			await options.postProcessor(cii);
 		}
 
 		return this.renderXML(cii);

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -5,10 +5,7 @@ import * as jsonpath from 'jsonpath-plus';
 import { FormatUBLService } from './format-ubl.service';
 import { EInvoiceFormat } from './format.e-invoice-format.interface';
 import { InvoiceServiceOptions } from '../invoice/invoice.service';
-
-// This is what we are looking at while traversing the input tree:
-export type Node = { [key: string]: Node } | Node[] | string;
-export type ObjectNode = { [key: string]: Node };
+import { ExpandObject } from 'xmlbuilder2/lib/interfaces';
 
 // Flags for Factur-X usage.
 export type FXProfile =
@@ -1665,10 +1662,9 @@ export class FormatCIIService
 
 	async generate(
 		invoice: Invoice,
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		_options: InvoiceServiceOptions,
+		options: InvoiceServiceOptions,
 	): Promise<string | Uint8Array> {
-		const cii: ObjectNode = {};
+		const cii: ExpandObject = {};
 
 		this.convert(invoice, '$', cii, '$', [ublInvoice]);
 
@@ -1690,10 +1686,14 @@ export class FormatCIIService
 
 		this.postProcess(cii);
 
+		if (options.postProcessor) {
+			options.postProcessor(cii);
+		}
+
 		return this.renderXML(cii);
 	}
 
-	private postProcess(cii: ObjectNode) {
+	private postProcess(cii: ExpandObject) {
 		this.postProcessSellerTradeParty(cii);
 
 		// If the delivery location ID does not have a scheme, downgrade it from
@@ -1739,7 +1739,7 @@ export class FormatCIIService
 		}
 	}
 
-	private postProcessSellerTradeParty(cii: ObjectNode) {
+	private postProcessSellerTradeParty(cii: ExpandObject) {
 		const sellerParty =
 			cii['rsm:CrossIndustryInvoice']?.['rsm:SupplyChainTradeTransaction']?.[
 				'ram:ApplicableHeaderTradeAgreement'
@@ -1775,7 +1775,7 @@ export class FormatCIIService
 		}
 
 		// Rebuild sellerParty with ram:ID and ram:GlobalID first.
-		const orderedSellerParty: ObjectNode = {};
+		const orderedSellerParty: ExpandObject = {};
 
 		// Add local IDs first.
 		if (localIDs.length) {
@@ -1806,7 +1806,7 @@ export class FormatCIIService
 	private convert(
 		invoice: Invoice,
 		srcPath: string,
-		dest: ObjectNode,
+		dest: ExpandObject,
 		destPath: string,
 		transformations: Transformation[],
 	) {
@@ -1917,9 +1917,9 @@ export class FormatCIIService
 	}
 
 	private vivifyDest(
-		dest: ObjectNode,
+		dest: ExpandObject,
 		path: string,
-		value: string | ObjectNode,
+		value: string | ExpandObject,
 	) {
 		const indices = path.replace(/\[([0-9]+)\]/g, '.$1').split('.');
 
@@ -1939,7 +1939,7 @@ export class FormatCIIService
 				dest[key] ??= {};
 			}
 
-			dest = dest[key] as ObjectNode;
+			dest = dest[key] as ExpandObject;
 		}
 
 		dest[indices[indices.length - 1]] = value;

--- a/packages/core/src/format/format-ubl.service.spec.ts
+++ b/packages/core/src/format/format-ubl.service.spec.ts
@@ -8,6 +8,7 @@ jest.mock('../utils/render-spreadsheet', () => ({
 
 import { FormatUBLService } from './format-ubl.service';
 import { InvoiceServiceOptions } from '../invoice/invoice.service';
+import { ExpandObject } from 'xmlbuilder2/lib/interfaces';
 
 describe('UBL', () => {
 	let service: FormatUBLService;
@@ -278,5 +279,58 @@ describe('UBL', () => {
 		await expect(service.generate(invoice, options)).rejects.toThrow(
 			'The attachment buffer is required!',
 		);
+	});
+
+	describe('post-processing', () => {
+		const defaultNotes = [
+			'Buy a dozen donuts at the Kwik-E-Mart and instantly become'
+			+ 'Homer-level happy—guaranteed to make your cat ignore you!',
+			'Order Bart\'s Skateboard Deluxe 3000 from the Simpson Garage'
+			+ 'because it\'s the only board that survives a launch over'
+			+ 'Grandpa\'s dentures!'
+		];
+
+		const postProcessor = (data: ExpandObject) => {
+			const document = data['Invoice'] ?? data['CreditNote'];
+			const notes = document['cbc:Note'];
+
+			if (notes) {
+				notes.push(...defaultNotes);
+			} else {
+				document['cbc:Note'] = [...defaultNotes];
+			}
+		};
+
+		it('should append default notes to invoice notes', async () => {
+			const invoice: Invoice = {
+				'ubl:Invoice': {
+					'cbc:ID': '1234567890',
+					'cbc:InvoiceTypeCode': '380',
+					'cbc:Note': ['Please send complaints to devnull@us.com'],
+				},
+			} as unknown as Invoice;
+			const options = {
+				postProcessor
+			} as InvoiceServiceOptions;
+
+			const xml = await service.generate(invoice, options);
+			expect(xml).toMatchSnapshot();
+		});
+
+		it('should append default notes to credit-note notes', async () => {
+			const invoice: Invoice = {
+				'ubl:Invoice': {
+					'cbc:ID': '1234567890',
+					'cbc:InvoiceTypeCode': '381',
+					'cbc:Note': ['Please send complaints to devnull@us.com'],
+				},
+			} as unknown as Invoice;
+			const options = {
+				postProcessor
+			} as InvoiceServiceOptions;
+
+			const xml = await service.generate(invoice, options);
+			expect(xml).toMatchSnapshot();
+		});
 	});
 });

--- a/packages/core/src/format/format-ubl.service.spec.ts
+++ b/packages/core/src/format/format-ubl.service.spec.ts
@@ -283,11 +283,11 @@ describe('UBL', () => {
 
 	describe('post-processing', () => {
 		const defaultNotes = [
-			'Buy a dozen donuts at the Kwik-E-Mart and instantly become'
-			+ 'Homer-level happy—guaranteed to make your cat ignore you!',
-			'Order Bart\'s Skateboard Deluxe 3000 from the Simpson Garage'
-			+ 'because it\'s the only board that survives a launch over'
-			+ 'Grandpa\'s dentures!'
+			'Buy a dozen donuts at the Kwik-E-Mart and instantly become' +
+				' Homer-level happy—guaranteed to make your cat ignore you!',
+			"Order Bart's Skateboard Deluxe 3000 from the Simpson Garage" +
+				" because it's the only board that survives a launch over" +
+				" Grandpa's dentures!",
 		];
 
 		const postProcessor = (data: ExpandObject) => {
@@ -310,7 +310,7 @@ describe('UBL', () => {
 				},
 			} as unknown as Invoice;
 			const options = {
-				postProcessor
+				postProcessor,
 			} as InvoiceServiceOptions;
 
 			const xml = await service.generate(invoice, options);
@@ -326,7 +326,7 @@ describe('UBL', () => {
 				},
 			} as unknown as Invoice;
 			const options = {
-				postProcessor
+				postProcessor,
 			} as InvoiceServiceOptions;
 
 			const xml = await service.generate(invoice, options);

--- a/packages/core/src/format/format-ubl.service.spec.ts
+++ b/packages/core/src/format/format-ubl.service.spec.ts
@@ -290,7 +290,7 @@ describe('UBL', () => {
 				" Grandpa's dentures!",
 		];
 
-		const postProcessor = (data: ExpandObject) => {
+		const postProcessor = async (data: ExpandObject) => {
 			const document = data['Invoice'] ?? data['CreditNote'];
 			const notes = document['cbc:Note'];
 

--- a/packages/core/src/format/format-ubl.service.ts
+++ b/packages/core/src/format/format-ubl.service.ts
@@ -133,7 +133,7 @@ export class FormatUBLService
 
 			const data = replaceInvoiceWithCreditNote(creditNoteObject);
 			if (options.postProcessor) {
-				options.postProcessor(data);
+				await options.postProcessor(data);
 			}
 			return this.renderXML(data);
 		} else {
@@ -149,7 +149,7 @@ export class FormatUBLService
 			};
 
 			if (options.postProcessor) {
-				options.postProcessor(invoiceObject);
+				await options.postProcessor(invoiceObject);
 			}
 			return this.renderXML(invoiceObject);
 		}

--- a/packages/core/src/format/format-ubl.service.ts
+++ b/packages/core/src/format/format-ubl.service.ts
@@ -131,7 +131,11 @@ export class FormatUBLService
 			// This field is not present in ubl:CreditNote.
 			delete creditNoteObject['CreditNote']['cbc:DueDate'];
 
-			return this.renderXML(replaceInvoiceWithCreditNote(creditNoteObject));
+			const data = replaceInvoiceWithCreditNote(creditNoteObject);
+			if (options.postProcessor) {
+				options.postProcessor(data);
+			}
+			return this.renderXML(data);
 		} else {
 			const invoiceObject = {
 				Invoice: {
@@ -144,6 +148,9 @@ export class FormatUBLService
 				},
 			};
 
+			if (options.postProcessor) {
+				options.postProcessor(invoiceObject);
+			}
 			return this.renderXML(invoiceObject);
 		}
 	}

--- a/packages/core/src/invoice/invoice.service.ts
+++ b/packages/core/src/invoice/invoice.service.ts
@@ -148,7 +148,7 @@ export type InvoiceServiceOptions = {
 	 * 	const notes =
 	 * 		data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument'][
 	 * 			'ram:IncludedNote'
-	 * 		]; *
+	 * 		];
 	 * 	for (const note of defaultNotes) {
 	 * 		notes.push({ 'ram:Content': note });
 	 * 	}

--- a/packages/core/src/invoice/invoice.service.ts
+++ b/packages/core/src/invoice/invoice.service.ts
@@ -5,6 +5,7 @@ import { invoiceSchema } from './invoice.schema';
 import { FormatFactoryService } from '../format/format.factory.service';
 import { Logger } from '../logger.interface';
 import { ValidationService } from '../validation';
+import { ExpandObject } from 'xmlbuilder2/lib/interfaces';
 
 /**
  * A container for a file used for an e-invoice.
@@ -80,6 +81,14 @@ export type InvoiceServiceOptions = {
 	 * Shut up warnings.
 	 */
 	noWarnings?: boolean;
+
+	/**
+	 * Callback for a function to call, before the XML is rendered. This
+	 * allows fine-tuning the output XML, for example by adding currently
+	 * unsupported CII elements. Another possible use-case is to apply fixes
+	 * for currently open bugs.
+	 */
+	postProcessor?: (cii: ExpandObject) => Promise<void>;
 };
 
 /**

--- a/packages/core/src/invoice/invoice.service.ts
+++ b/packages/core/src/invoice/invoice.service.ts
@@ -83,12 +83,79 @@ export type InvoiceServiceOptions = {
 	noWarnings?: boolean;
 
 	/**
-	 * Callback for a function to call, before the XML is rendered. This
+	 * Callback function invoked before the XML is rendered. This
 	 * allows fine-tuning the output XML, for example by adding currently
-	 * unsupported CII elements. Another possible use-case is to apply fixes
-	 * for currently open bugs.
+	 * unsupported CII elements. Another use case is applying fixes for open
+	 * bugs.
+	 *
+	 * The `data` argument is a plain JavaScript object where all nodes
+	 * are either an `Array` or another object, and all leaves are
+	 * strings. The type `ExpandObject` is defined in `xmlbuilder2`.
+	 *
+	 * UBL example:
+	 *
+	 * ```typescript
+	 * const defaultNotes = [
+	 *	'We only use organic ingredients (no GMO)!',
+	 *	'We work exclusively with regional suppliers.',
+	 * ];
+	 *
+	 * invoiceServiceOptions.postProcessor = async (data: ExpandObject) => {
+	 *	const document = data['Invoice'] ?? data['CreditNote'];
+	 *	const notes = document['cbc:Note'];
+	 *
+	 *	if (notes) {
+	 *		notes.push(...defaultNotes);
+	 *	} else {
+	 *		document['cbc:Note'] = [...defaultNotes];
+	 *	}
+	 * ```
+	 *
+	 * CII example:
+	 *
+	 * ```typescript
+	 * const defaultNotes = [
+	 *	'We only use organic ingredients (no GMO)!',
+	 *	'We work exclusively with regional suppliers.',
+	 * ];
+	 *
+	 * const postProcessor = async (data: ExpandObject) => {
+	 * 	if (
+	 * 		data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+	 * 			'ram:IncludedNote'
+	 * 		]
+	 * 	) {
+	 * 		if (
+	 * 			!Array.isArray(
+	 * 				data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+	 * 					'ram:IncludedNote'
+	 * 				],
+	 * 			)
+	 * 		) {
+	 * 			data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+	 * 				'ram:IncludedNote'
+	 * 			] = [
+	 * 				data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+	 * 					'ram:IncludedNote'
+	 * 				],
+	 * 			];
+	 * 		}
+	 * 	} else {
+	 * 		data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument']![
+	 * 			'ram:IncludedNote'
+	 * 		] = [];
+	 * 	}
+	 * 	const notes =
+	 * 		data['rsm:CrossIndustryInvoice']['rsm:ExchangedDocument'][
+	 * 			'ram:IncludedNote'
+	 * 		]; *
+	 * 	for (const note of defaultNotes) {
+	 * 		notes.push({ 'ram:Content': note });
+	 * 	}
+	 * };
+	 * ```
 	 */
-	postProcessor?: (cii: ExpandObject) => Promise<void>;
+	postProcessor?: (data: ExpandObject) => Promise<void>;
 };
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional post-processing hook to allow custom modification of invoice data before XML rendering across supported formats.
* **Tests**
  * Added test coverage validating post-processing behavior for various document types and XML outputs.
* **Documentation**
  * Added release notes describing the post-processing capability, its scope/limitations (not enabled for CLI/REST), and hybrid Factur‑X/ZUGFeRD handling details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->