### PR TITLE
Fix coverage delta action

### DIFF
--- a/.github/workflows/coverage-delta-comment.yaml
+++ b/.github/workflows/coverage-delta-comment.yaml
@@ -23,8 +23,9 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: coverage-delta
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
           run-id: ${{ github.event.workflow_run.id }}
-
       - name: Extract PR number
         id: pr
         run: |

--- a/.github/workflows/coverage-delta-comment.yaml
+++ b/.github/workflows/coverage-delta-comment.yaml
@@ -45,13 +45,18 @@ jobs:
             const body = fs.readFileSync('coverage-delta.md', 'utf-8')
             const issue_number = Number(process.env.PR_NUMBER)
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
+              per_page: 100,
             })
 
-            const existing = comments.find(c => c.body?.includes("**Coverage Delta**"))
+            const existing = comments.find(
+              c =>
+                c.user?.login === 'github-actions[bot]' &&
+                c.body?.includes("**Coverage Delta**")
+            )
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/coverage-delta-comment.yaml
+++ b/.github/workflows/coverage-delta-comment.yaml
@@ -28,7 +28,14 @@ jobs:
       - name: Extract PR number
         id: pr
         run: |
-          echo "PR_NUMBER=$(jq -r '.pull_requests[0].number' <<< '${{ toJson(github.event.workflow_run) }}')" >> $GITHUB_ENV
+          PR_NUMBER=$(jq -r '.pull_requests[0].number // empty' <<< "$WORKFLOW_RUN")
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::error::Could not extract PR number from workflow_run event"
+            exit 1
+          fi
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        env:
+          WORKFLOW_RUN: ${{ toJson(github.event.workflow_run) }}
 
       - name: Comment on PR (update existing)
         uses: actions/github-script@v9
@@ -44,7 +51,7 @@ jobs:
               repo: context.repo.repo,
             })
 
-            const existing = comments.find(c => c.body.includes("**Coverage Delta**"))
+            const existing = comments.find(c => c.body?.includes("**Coverage Delta**"))
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/coverage-delta-comment.yaml
+++ b/.github/workflows/coverage-delta-comment.yaml
@@ -1,0 +1,63 @@
+name: Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["Coverage Delta"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download coverage delta artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage-delta
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract PR number
+        id: pr
+        run: |
+          echo "PR_NUMBER=$(jq -r '.pull_requests[0].number' <<< '${{ toJson(github.event.workflow_run) }}')" >> $GITHUB_ENV
+
+      - name: Comment on PR (update existing)
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs')
+            const body = fs.readFileSync('coverage-delta.md', 'utf-8')
+            const issue_number = Number(process.env.PR_NUMBER)
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+
+            const existing = comments.find(c => c.body.includes("**Coverage Delta**"))
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              })
+            } else {
+              await github.rest.issues.createComment({
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              })
+            }

--- a/.github/workflows/coverage-delta-comment.yaml
+++ b/.github/workflows/coverage-delta-comment.yaml
@@ -28,14 +28,12 @@ jobs:
       - name: Extract PR number
         id: pr
         run: |
-          PR_NUMBER=$(jq -r '.pull_requests[0].number // empty' <<< "$WORKFLOW_RUN")
-          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
-            echo "::error::Could not extract PR number from workflow_run event"
+          PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not extract a valid numeric PR number from workflow_run event"
             exit 1
           fi
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-        env:
-          WORKFLOW_RUN: ${{ toJson(github.event.workflow_run) }}
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
 
       - name: Comment on PR (update existing)
         uses: actions/github-script@v9

--- a/.github/workflows/coverage-delta.yaml
+++ b/.github/workflows/coverage-delta.yaml
@@ -9,7 +9,6 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout PR branch
@@ -52,33 +51,8 @@ jobs:
           set -euo pipefail
           node compare-coverage.mjs | tee coverage-delta.md
 
-      - name: Comment on PR (update existing)
-        uses: actions/github-script@v8
+      - name: Upload coverage delta
+        uses: actions/upload-artifact@v7
         with:
-          script: |
-            const fs = require('fs')
-            const body = fs.readFileSync('coverage-delta.md', 'utf-8')
-
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            })
-
-            const existing = comments.find(c => c.body.includes("**Coverage Delta**"))
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                comment_id: existing.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body
-              })
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body
-              })
-            }
+          name: coverage-delta
+          path: coverage-delta.md

--- a/.trivyignore
+++ b/.trivyignore
@@ -13,8 +13,3 @@ CVE-2026-31802
 # Date: 2026-04-02
 # Vulnerability in picomatch. This is part of npm but npm is not used.
 CVE-2026-33671
-
-# Date: 2026-04-04
-# Vulnerability in libinput-libs. This seems to be a false positive.
-# The library is not present in the image.
-CVE-2026-35093

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -48,7 +48,11 @@ RUN if [ "$WITH_LIBREOFFICE" != "false" ]; then \
 		font-noto-emoji; \
 	fi
 
-RUN apk update && apk upgrade
+# Upgrade all packages to latest.
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main" > /etc/apk/repositories \
+  && echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories \
+  && apk update \
+  && apk upgrade --no-cache
 
 WORKDIR /app
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated step that posts or updates a "Coverage Delta" comment on pull requests after coverage runs complete, and adjusted the coverage pipeline to publish the coverage report as an artifact while reducing write permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->