### PR TITLE
use new tag schema

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -51,7 +51,7 @@ jobs:
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
           fi
 
-      # Extract version (strip leading "v")
+      # Extract version (strip leading "@e-invoice-eu/server@")
       - name: Extract version
         id: version
         run: |

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -56,7 +56,7 @@ jobs:
         id: version
         run: |
           if [ "${{ startsWith(github.ref, 'refs/tags/') }}" = "true" ]; then
-            VERSION=${GITHUB_REF_NAME#v}
+            VERSION=${GITHUB_REF_NAME#@e-invoice-eu/server@}
             echo "version=$VERSION" >> $GITHUB_OUTPUT
           else
             echo "version=ci" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -3,7 +3,7 @@ name: Docker Publish (DockerHub)
 on:
   push:
     branches: ['**']
-    tags: [ 'v*.*.*' ]
+    tags: [ '@e-invoice-eu/server@*.*.*' ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined Docker image publishing workflow to run only for matching release tags.
  * Adjusted versioning behavior so non-tag builds are labeled as "ci".
  * No changes to image naming, tags, or runtime behavior were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->