### PR TITLE
uninstall npm and corepack in runner stage

### DIFF
--- a/.changeset/every-carrots-behave.md
+++ b/.changeset/every-carrots-behave.md
@@ -1,0 +1,7 @@
+---
+"@e-invoice-eu/server": patch
+---
+
+Uninstall npm and corepack in docker image.
+
+This reduces the attack surface and avoids false positives from Trivy.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,1 @@
 # The CVEs in this file are ignored.
-
-# Date: 2026-04-02
-# Vulnerability in picomatch. This is part of npm but npm is not used.
-CVE-2026-33671

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -54,8 +54,10 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main" > /etc/apk/r
   && echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories \
   && apk update \
   && apk upgrade --no-cache \
-  && rm -rf /usr/local/lib/node_modules/npm \
-  && rm -rf /usr/local/lib/node_modules/corepack
+  && rm -r /usr/local/lib/node_modules/npm \
+  	/usr/local/bin/npm \
+  	/usr/local/lib/node_modules/corepack \
+	/usr/local/bin/corepack
 
 WORKDIR /app
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -48,11 +48,14 @@ RUN if [ "$WITH_LIBREOFFICE" != "false" ]; then \
 		font-noto-emoji; \
 	fi
 
-# Upgrade all packages to latest.
+# Upgrade all packages to latest. Also, uninstall npm and corepack. They only
+# drag in security issues.
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main" > /etc/apk/repositories \
   && echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories \
   && apk update \
-  && apk upgrade --no-cache
+  && apk upgrade --no-cache \
+  && rm -rf /usr/local/lib/node_modules/npm \
+  && rm -rf /usr/local/lib/node_modules/corepack
 
 WORKDIR /app
 


### PR DESCRIPTION
This reduces the attack surface and avoids false positive security issues.