### PR TITLE
Preserve Property Order, when Downgrading ram:GlobalID to ram:ID

### DIFF
--- a/.changeset/polite-boxes-boil.md
+++ b/.changeset/polite-boxes-boil.md
@@ -1,0 +1,8 @@
+---
+"@e-invoice-eu/core": patch
+"@e-invoice-eu/server": patch
+"@e-invoice-eu/cli": patch
+"@e-invoice-eu/docs": patch
+---
+
+Preserve correct ID, when downgrading ram:GlobalID to ram:ID (#567).

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -103,6 +103,70 @@ exports[`CII > regressions > #490 adapt seller party mappings depending on it at
 </rsm:CrossIndustryInvoice>"
 `;
 
+exports[`CII > regressions > #567 fix element order > should use the right order for schemeless customer party IDs 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:BuyerTradeParty>
+				<ram:ID>42</ram:ID>
+				<ram:SpecifiedLegalOrganization>
+					<ram:TradingBusinessName>Acme Ltd.</ram:TradingBusinessName>
+				</ram:SpecifiedLegalOrganization>
+			</ram:BuyerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
+exports[`CII > regressions > #567 fix element order > should use the right order for schemeless delivery location ID 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeDelivery>
+			<ram:ShipToTradeParty>
+				<ram:ID>42</ram:ID>
+				<ram:PostalTradeAddress>
+					<ram:CountryID>BG</ram:CountryID>
+				</ram:PostalTradeAddress>
+			</ram:ShipToTradeParty>
+		</ram:ApplicableHeaderTradeDelivery>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
+exports[`CII > regressions > #567 fix element order > should use the right order for schemeless ship-to trade party IDs 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:SellerTradeParty>
+				<ram:ID>42</ram:ID>
+				<ram:SpecifiedLegalOrganization>
+					<ram:TradingBusinessName>Acme Ltd.</ram:TradingBusinessName>
+				</ram:SpecifiedLegalOrganization>
+			</ram:SellerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
+exports[`CII > regressions > #567 fix element order > should use the right order for schemeless supplier party IDs 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+	<rsm:SupplyChainTradeTransaction>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:SellerTradeParty>
+				<ram:ID>42</ram:ID>
+				<ram:SpecifiedLegalOrganization>
+					<ram:TradingBusinessName>Acme Ltd.</ram:TradingBusinessName>
+				</ram:SpecifiedLegalOrganization>
+			</ram:SellerTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>"
+`;
+
 exports[`CII > should convert arrays 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">

--- a/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
+++ b/packages/core/src/format/__snapshots__/format-cii.service.spec.ts.snap
@@ -135,22 +135,6 @@ exports[`CII > regressions > #567 fix element order > should use the right order
 </rsm:CrossIndustryInvoice>"
 `;
 
-exports[`CII > regressions > #567 fix element order > should use the right order for schemeless ship-to trade party IDs 1`] = `
-"<?xml version="1.0" encoding="utf-8"?>
-<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
-	<rsm:SupplyChainTradeTransaction>
-		<ram:ApplicableHeaderTradeAgreement>
-			<ram:SellerTradeParty>
-				<ram:ID>42</ram:ID>
-				<ram:SpecifiedLegalOrganization>
-					<ram:TradingBusinessName>Acme Ltd.</ram:TradingBusinessName>
-				</ram:SpecifiedLegalOrganization>
-			</ram:SellerTradeParty>
-		</ram:ApplicableHeaderTradeAgreement>
-	</rsm:SupplyChainTradeTransaction>
-</rsm:CrossIndustryInvoice>"
-`;
-
 exports[`CII > regressions > #567 fix element order > should use the right order for schemeless supplier party IDs 1`] = `
 "<?xml version="1.0" encoding="utf-8"?>
 <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100 ../schema/D16B%20SCRDM%20(Subset)/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">

--- a/packages/core/src/format/format-cii.service.spec.ts
+++ b/packages/core/src/format/format-cii.service.spec.ts
@@ -342,5 +342,91 @@ describe('CII', () => {
 				expect(xml).toMatchSnapshot();
 			});
 		});
+
+		describe('#567 fix element order', () => {
+			it('should use the right order for schemeless supplier party IDs', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:AccountingSupplierParty': {
+							'cac:Party': {
+								'cac:PartyIdentification': [
+									{
+										'cbc:ID': '42',
+									},
+								],
+								// Make sure that this will come last in the
+								// XML output.
+								'cac:PartyName': {
+									'cbc:Name': 'Acme Ltd.',
+								},
+							},
+						},
+					},
+				} as unknown as Invoice;
+				const xml = await service.generate(
+					invoice,
+					{} as InvoiceServiceOptions,
+				);
+				expect(xml).toContain('<ram:ID>42</ram:ID>');
+				expect(xml).not.toContain('<ram:GlobalID>42</ram:GlobalID>');
+				// The snapshot test ensures that all local IDs precede the
+				// global IDs.
+				expect(xml).toMatchSnapshot();
+			});
+
+			it('should use the right order for schemeless customer party IDs', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:AccountingCustomerParty': {
+							'cac:Party': {
+								'cac:PartyIdentification': {
+									'cbc:ID': '42',
+								},
+								// Make sure that this will come last in the
+								// XML output.
+								'cac:PartyName': {
+									'cbc:Name': 'Acme Ltd.',
+								},
+							},
+						},
+					},
+				} as unknown as Invoice;
+				const xml = await service.generate(
+					invoice,
+					{} as InvoiceServiceOptions,
+				);
+				expect(xml).toContain('<ram:ID>42</ram:ID>');
+				expect(xml).not.toContain('<ram:GlobalID>42</ram:GlobalID>');
+				// The snapshot test ensures that all local IDs precede the
+				// global IDs.
+				expect(xml).toMatchSnapshot();
+			});
+
+			it('should use the right order for schemeless delivery location ID', async () => {
+				const invoice: Invoice = {
+					'ubl:Invoice': {
+						'cac:Delivery': {
+							'cac:DeliveryLocation': {
+								'cbc:ID': '42',
+								'cac:Address': {
+									'cac:Country': {
+										'cbc:IdentificationCode': 'BG',
+									},
+								},
+							},
+						},
+					},
+				} as unknown as Invoice;
+				const xml = await service.generate(
+					invoice,
+					{} as InvoiceServiceOptions,
+				);
+				expect(xml).toContain('<ram:ID>42</ram:ID>');
+				expect(xml).not.toContain('<ram:GlobalID>42</ram:GlobalID>');
+				// The snapshot test ensures that all local IDs precede the
+				// global IDs.
+				expect(xml).toMatchSnapshot();
+			});
+		});
 	});
 });

--- a/packages/core/src/format/format-cii.service.ts
+++ b/packages/core/src/format/format-cii.service.ts
@@ -3,6 +3,7 @@ import { type JSONSchemaType } from 'ajv';
 import * as jsonpath from 'jsonpath-plus';
 import { ExpandObject } from 'xmlbuilder2/lib/interfaces';
 import { InvoiceServiceOptions } from '../invoice/invoice.service';
+import { renameKey } from '../utils/rename-key';
 import { EInvoiceFormat } from './format.e-invoice-format.interface';
 import { FormatUBLService } from './format-ubl.service';
 
@@ -1742,8 +1743,7 @@ export class FormatCIIService
 			buyerParty?.['ram:GlobalID'] &&
 			!buyerParty['ram:GlobalID@schemeID']
 		) {
-			buyerParty['ram:ID'] = buyerParty['ram:GlobalID'];
-			delete buyerParty['ram:GlobalID'];
+			renameKey(buyerParty, 'ram:GlobalID', 'ram:ID');
 		}
 
 		// Same as above.
@@ -1753,8 +1753,7 @@ export class FormatCIIService
 			]?.['ram:ApplicableHeaderTradeDelivery']?.['ram:ShipToTradeParty'];
 
 		if (shipTo?.['ram:GlobalID'] && !shipTo['ram:GlobalID@schemeID']) {
-			shipTo['ram:ID'] = shipTo['ram:GlobalID'];
-			delete shipTo['ram:GlobalID'];
+			renameKey(shipTo, 'ram:GlobalID', 'ram:ID');
 		}
 
 		const supplierTaxRegistration =

--- a/packages/core/src/utils/rename-key.spec.ts
+++ b/packages/core/src/utils/rename-key.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { renameKey } from './rename-key';
+
+describe('Object key renaming in-place', () => {
+	it('should keep the object order', () => {
+		const obj = {
+			parent: {
+				leftSibling: {},
+				changeMe: {
+					foo: 1,
+					bar: 2,
+					baz: 3,
+				},
+				rightSibling: {},
+			},
+		};
+		renameKey(obj.parent.changeMe, 'bar', 'barbar');
+		expect(obj).toStrictEqual({
+			parent: {
+				leftSibling: {},
+				changeMe: {
+					foo: 1,
+					barbar: 2,
+					baz: 3,
+				},
+				rightSibling: {},
+			},
+		});
+	});
+});

--- a/packages/core/src/utils/rename-key.ts
+++ b/packages/core/src/utils/rename-key.ts
@@ -1,0 +1,18 @@
+export function renameKey(
+	obj: Record<string, unknown>,
+	oldKey: string,
+	newKey: string,
+): void {
+	const entries = Object.keys(obj).map(key => [
+		key === oldKey ? newKey : key,
+		obj[key],
+	]);
+
+	for (const key of Object.keys(obj)) {
+		delete obj[key];
+	}
+
+	for (const [key, value] of entries) {
+		obj[key as keyof typeof obj] = value;
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved correct local IDs when converting invoices with schemeless identifiers.
  * Ensured local IDs appear as `ram:ID` instead of `ram:GlobalID`.
  * Corrected XML element ordering for supplier, customer, and delivery location identifiers.

* **Tests**
  * Added regression coverage for identifier conversion and ordering.
  * Added coverage for key-renaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->