### PR TITLE
remove ignored docs package from changeset

### DIFF
--- a/.changeset/odd-bikes-float.md
+++ b/.changeset/odd-bikes-float.md
@@ -1,6 +1,5 @@
 ---
 "@e-invoice-eu/core": minor
-"@e-invoice-eu/docs": minor
 "@e-invoice-eu/server": minor
 "@e-invoice-eu/cli": minor
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Supplier or payee party identifiers using the SEPA scheme are now mapped to the CII creditor reference ID (BT-90).
  - Payee identifiers take precedence when both payee and supplier identifiers are available.
  - When supplier identifiers conflict, the first applicable supplier identifier is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->